### PR TITLE
ページネーションスマホ対応

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -10,6 +10,7 @@ import {
   MenuItem,
   MenuList,
   Text,
+  textDecoration,
 } from "@chakra-ui/react";
 import { ArrowForwardIcon } from "@chakra-ui/icons";
 import { SITE_NAME, MAIN_COLOR } from "utils/constants";
@@ -35,7 +36,12 @@ const Header: React.FC = () => {
       <Heading as="h1" fontSize={{ base: "md", md: "xl" }}>
         <Link href="/">
           {/* next/linkだとデフォルトでホバーした時に青くなってしまうので無効化 */}
-          <Text _hover={{ color: "gray.50" }}>{SITE_NAME}</Text>
+          <Text
+            _hover={{ color: "gray.50", textDecoration: "none" }}
+            color="gray.50"
+          >
+            {SITE_NAME}
+          </Text>
         </Link>
       </Heading>
     );

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -4,8 +4,7 @@ import { ChakraProvider } from "@chakra-ui/react";
 import { SessionProvider } from "next-auth/react";
 import { AppProps } from "next/app";
 import { GoogleAnalytics } from "nextjs-google-analytics";
-import "bootstrap/dist/css/bootstrap.min.css";
-import "styles/scroll.css";
+import "styles/pagination.css";
 
 const App = ({ Component, pageProps }: AppProps) => {
   return (

--- a/styles/pagination.css
+++ b/styles/pagination.css
@@ -6,14 +6,15 @@
   justify-content: center;
   margin-bottom: 15px;
   margin-top: 15px;
-  gap: 20px 1px;
+  gap: 20px 0px;
 }
 
 .page-item,
 .page-link {
   display: inline-flex;
   align-items: center;
-  border-radius: 5px;
+  color: #3182CE;
+  border-radius: 3px;
   justify-content: center;
   font-size: 16px;
   height: 36px;

--- a/styles/pagination.css
+++ b/styles/pagination.css
@@ -13,22 +13,21 @@
 .page-link {
   display: inline-flex;
   align-items: center;
-  color: #3182CE;
   border-radius: 3px;
   justify-content: center;
   font-size: 16px;
-  height: 36px;
-  width: 36px;
+  height: 34px;
+  width: 34px;
 }
 
 .page-item:hover,
 .page-link:hover {
-  color: #3182CE;
   background-color: #F7FAFC;
 }
 
 .active {
-  border: 1px solid #CBD5E0;
-  color: #3182CE;
+  border: 1px solid #E2E8F0;
+  background-color: #EDF2F7;
+  color: #FFF;
   font-weight: bold;
 }

--- a/styles/pagination.css
+++ b/styles/pagination.css
@@ -6,7 +6,7 @@
   justify-content: center;
   margin-bottom: 15px;
   margin-top: 15px;
-  gap: 20px 2px;
+  gap: 20px 1px;
 }
 
 .page-item,

--- a/styles/pagination.css
+++ b/styles/pagination.css
@@ -1,18 +1,20 @@
+/* chakraのgrayカラーで統一 */
+/* リンクのカラーはトップページのリンクと統一 */
 .pagination {
   display: flex;
   align-items: center;
   justify-content: center;
-  margin-bottom: 10px;
-  gap: 20px 4px;
+  margin-bottom: 15px;
+  margin-top: 15px;
+  gap: 20px 2px;
 }
 
 .page-item,
 .page-link {
   display: inline-flex;
   align-items: center;
-  border-radius: 30px;
+  border-radius: 5px;
   justify-content: center;
-  font-weight: 700;
   font-size: 16px;
   height: 36px;
   width: 36px;
@@ -20,12 +22,12 @@
 
 .page-item:hover,
 .page-link:hover {
-  color: #000;
-  background-color: #735050;
-  border: 1px solid #e5e5e5;
+  color: #3182CE;
+  background-color: #F7FAFC;
 }
 
 .active {
-  background-color: #f5f5f5;
-  color: #000;
+  border: 1px solid #CBD5E0;
+  color: #3182CE;
+  font-weight: bold;
 }

--- a/styles/pagination.css
+++ b/styles/pagination.css
@@ -1,0 +1,31 @@
+.pagination {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 10px;
+  gap: 20px 4px;
+}
+
+.page-item,
+.page-link {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 30px;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 16px;
+  height: 36px;
+  width: 36px;
+}
+
+.page-item:hover,
+.page-link:hover {
+  color: #000;
+  background-color: #735050;
+  border: 1px solid #e5e5e5;
+}
+
+.active {
+  background-color: #f5f5f5;
+  color: #000;
+}

--- a/styles/scroll.css
+++ b/styles/scroll.css
@@ -1,4 +1,0 @@
-html {
-  /* bootstrapでのscroll-behavior設定を上書きするための記述 */
-  scroll-behavior: auto !important;
-}

--- a/styles/theme.ts
+++ b/styles/theme.ts
@@ -13,6 +13,12 @@ const theme = extendTheme({
       body: {
         backgroundColor: "gray.40",
         color: "gray.800",
+        a: {
+          color: "blue.500",
+          _hover: {
+            textDecoration: "underline",
+          },
+        },
       },
     },
   },


### PR DESCRIPTION
### やったこと
- bootstrapを削除してcssで対応（削除するとscrollが適法されるのでscroll.css削除）
- スマホでページネーションが横長すぎてデザインが崩れてた部分解消
- リンクを青色でホバーアンダーライン引かれるように修正(chakraのthemeにて)

### 今後
- トップのロゴでホバーアンダーラインが入っているのですが、次ロゴsvgにするので修正されます