### PR TITLE
github hooksでredeployを実行

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -2,7 +2,7 @@ name: 8am-daily
 on:
   schedule:
     # 08:00(JST) -> 23:00(UTC)
-    - cron: '30 4 * * *'
+    - cron: '0 23 * * *'
 jobs:
   cron:
     runs-on: ubuntu-latest

--- a/src/pages/[id].tsx
+++ b/src/pages/[id].tsx
@@ -96,7 +96,6 @@ export const getStaticProps: GetStaticProps = async (context) => {
 
     return {
       props: { feedbacks, projectName: name, updatedTime },
-      revalidate: 240,
     };
   } catch (error) {
     console.log(error);


### PR DESCRIPTION
レビューなしで大丈夫です。isrを調べて使えそうならできればisrを使いたい。もしどうしても無理だったらこちらを導入します。

### やったこと
- 確認のためにcronの時間を変更していたので朝8時に修正（一日一回朝8時にデプロイされるようになってます）
- このバージョンではisrを使ってないので削除
