### PR TITLE
cronでのアップデート間隔を2時間に

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -1,4 +1,4 @@
-name: hourly-update
+name: every-2hour-update
 on:
   schedule:
   # 毎時0分にデプロイ

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -2,7 +2,7 @@ name: hourly-update
 on:
   schedule:
   # 毎時0分にデプロイ
-    - cron: '0 * * * *'
+    - cron: "0 */2 * * *"
 jobs:
   cron:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### やったこと
- cronでのアップデート間隔を1時間だったところを2時間にした

### 背景
- 何回かに一度（17回デプロイ中2回）、vercelでデプロイエラーが発生していた
- 理由は、access_tokenの有効期限切れ
- access_tokenの有効期限が1時間で、アップデートも1時間にしているからではないかとの予測のもと上記変更を実施